### PR TITLE
Rename control port constant

### DIFF
--- a/tbcrawler/torcontroller.py
+++ b/tbcrawler/torcontroller.py
@@ -76,7 +76,7 @@ class TorController(object):
         self.log_file = logfile
         self.tmp_tor_data_dir = ut.clone_dir_with_timestap(self.tor_data_path)
 
-        self.torrc_dict.update({'ControlPort': str(cm.REFACTOR_CONTROL_PORT),
+        self.torrc_dict.update({'ControlPort': str(cm.DEFAULT_CONTROL_PORT),
                                 'DataDirectory': self.tmp_tor_data_dir,
                                 'Log': ['INFO file %s' % logfile]})
 
@@ -88,10 +88,10 @@ class TorController(object):
             tor_cmd=self.tor_binary_path,
             timeout=270
         )
-        self.controller = Controller.from_port(port=cm.REFACTOR_CONTROL_PORT)
+        self.controller = Controller.from_port(port=cm.DEFAULT_CONTROL_PORT)
         self.controller.authenticate()
         print("Tor running at port {0} & controller port {1}."
-              .format(cm.DEFAULT_SOCKS_PORT, cm.REFACTOR_CONTROL_PORT))
+              .format(cm.DEFAULT_SOCKS_PORT, cm.DEFAULT_CONTROL_PORT))
         return self.tor_process
 
     def close_all_streams(self):


### PR DESCRIPTION
This is to match the upcoming change in the tor-browser-selenium library.
