### PR TITLE
post visit needs to have the driver launched

### DIFF
--- a/tbcrawler/crawler.py
+++ b/tbcrawler/crawler.py
@@ -60,8 +60,8 @@ class CrawlerBase(object):
                         self.driver.get_screenshot_as_file(self.job.png_file)
                     except WebDriverException:
                         wl_log.error("Cannot get screenshot.")
+                self.post_visit()
             sleep(float(self.job.config['pause_between_visits']))
-            self.post_visit()
 
     def __do_visit(self):
         with Sniffer(path=self.job.pcap_file, filter=cm.DEFAULT_FILTER):


### PR DESCRIPTION
_post_visit uses stem to get the Guards ips and filter all the traffic
that do not originate from or destinate to them.

When the driver closes (i.e. when the with statement is finished), stem
socket is closed. Thus, we need to call _post_visit within the with
statement of the driver.
