### PR TITLE
XvfbWrapper, host list to tbdriver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ requests
 stem
 psutil>=2.2.1
 scapy
-xvfbwrapper
+pyvirtualdisplay
 selenium>=2.45.0
 tld
 -e git+https://github.com/webfp/tor-browser-selenium.git#egg=tbselenium-1.0

--- a/tbcrawler/common.py
+++ b/tbcrawler/common.py
@@ -29,8 +29,13 @@ DEFAULT_SOCKS_PORT = 9051
 CRAWLER_TYPES = ['Base', 'WebFP', 'Multitab']
 
 # virtual display dimensions
-XVFB_W = 1280
-XVFB_H = 720
+DEFAULT_XVFB_WIN_W = 1280
+DEFAULT_XVFB_WIN_H = 800
+# virt_display is a string in the form of WxH
+# W = width of the virtual display
+# H = height of the virtual display
+# e.g. "1280x800" or "800x600"
+DEFAULT_XVFB_WINDOW_SIZE = "%sx%s" % (DEFAULT_XVFB_WIN_W, DEFAULT_XVFB_WIN_H)
 
 # Default paths
 BASE_DIR = abspath(join(dirname(__file__), pardir))

--- a/tbcrawler/torcontroller.py
+++ b/tbcrawler/torcontroller.py
@@ -7,7 +7,6 @@ import stem.process
 from stem.control import Controller
 from stem.util import term
 from tbselenium.common import DEFAULT_TOR_DATA_PATH, DEFAULT_TOR_BINARY_PATH
-from tbselenium.utils import clone_dir_temporary
 
 import common as cm
 import utils as ut
@@ -79,7 +78,7 @@ class TorController(object):
     def launch_tor_service(self):
         """Launch Tor service and return the process."""
         if self.pollute:
-            self.tmp_tor_data_dir = clone_dir_temporary(self.tor_data_path)
+            self.tmp_tor_data_dir = ut.clone_dir_temporary(self.tor_data_path)
             self.torrc_dict.update({'DataDirectory': self.tmp_tor_data_dir})
 
         print("Tor config: %s" % self.torrc_dict)

--- a/tbcrawler/utils.py
+++ b/tbcrawler/utils.py
@@ -33,6 +33,14 @@ def create_dir(dir_path):
     return dir_path
 
 
+def clone_dir_temporary(dir_path):
+    """Makes a temporary copy of a directory."""
+    import tempfile
+    tempdir = tempfile.mkdtemp()
+    du.copy_tree(dir_path, tempdir)
+    return tempdir
+
+
 def append_timestamp(_str=''):
     """Append a timestamp to a string and return it."""
     return _str + strftime('%y%m%d_%H%M%S')

--- a/tbcrawler/xvfb.py
+++ b/tbcrawler/xvfb.py
@@ -1,0 +1,14 @@
+from pyvirtualdisplay import Display
+import common as cm
+
+
+def start_xvfb(win_width=cm.DEFAULT_XVFB_WIN_W,
+               win_height=cm.DEFAULT_XVFB_WIN_H):
+    xvfb_display = Display(visible=0, size=(win_width, win_height))
+    xvfb_display.start()
+    return xvfb_display
+
+
+def stop_xvfb(xvfb_display):
+    if xvfb_display:
+        xvfb_display.stop()


### PR DESCRIPTION
tor-browser-selenium removed the support of
Xvfb (webfp/tor-browser-selenium@e45b1d5),
now it is handled by the crawler itself. The same functions have been
moved to xvfb.py.

The display is closed after the crawl is finished, regardless of an
exception happened or not.

Also, tor-browser-selenium now expects a list of hostnames instead of a
list of urls to process the canvas exceptions (now named
canvas_allowed_hosts due to webfp/tor-browser-selenium@716605a).

edited: new commit message from https://github.com/webfp/tor-browser-crawler/pull/13/commits/7b8593d5d372c9f5febe301014d0c571d069d900
