### PR TITLE
The parent of the process may not be the shell

### DIFF
--- a/tbcrawler/dumputils.py
+++ b/tbcrawler/dumputils.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import time
+import psutil
 
 import common as cm
 import utils as ut
@@ -64,6 +65,8 @@ class Sniffer(object):
         self.is_recording = True
 
     def is_dumpcap_running(self):
+        if "dumpcap" in psutil.Process(self.p0.pid).cmdline():
+            return self.p0.returncode is None
         for proc in ut.gen_all_children_procs(self.p0.pid):
             if "dumpcap" in proc.cmdline():
                 return True


### PR DESCRIPTION
In an EC2 instance with Amazon Linux, dumpcap was running but
is_dumpcap_running said it wasn't. The problem may be that in
CentOS (the base of Amazon Linux) the shell=True does not make the popen
command to run under a shell, but rather directly as a process. So there
is no parent, the Popen object is the dumpcap process itself.
