### PR TITLE
Detect captcha in page, change in dir name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
+*~
 *.pyc
 tags
 tbb/
 src/
 results/
 .idea/
+.cache
+tbselenium
+tor-browser_*-*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 stem
 psutil>=2.2.1
+netifaces>=0.10.4
 pyvirtualdisplay
 selenium>=2.45.0
 -e git+https://github.com/webfp/tor-browser-selenium.git#egg=tbselenium-1.0

--- a/tbcrawler/crawler.py
+++ b/tbcrawler/crawler.py
@@ -135,7 +135,7 @@ class CrawlJob(object):
             captcha_filepath = ut.capture_dirpath_to_captcha(self.path)
             rename(self.path, captcha_filepath)
 
-            self.captchas[self.instance] = True
+            self.captchas[self.global_visit] = True
         except OSError as e:
             wl_log.exception('%s could not be renamed to %s',
                              self.path, captcha_filepath)
@@ -154,14 +154,18 @@ class CrawlJob(object):
         return self.batch * self.visits + self.visit
 
     @property
+    def global_visit(self):
+        global_visit_no = self.site * self.visits + self.instance
+        return global_visit_no
+
+    @property
     def url(self):
         return self.urls[self.site]
 
     @property
     def path(self):
         attributes = [self.batch, self.site, self.instance]
-        if self.captchas[self.instance]:
-            wl_log.debug('Instance %i is a captcha', self.instance)
+        if self.captchas[self.global_visit]:
             attributes.insert(0, 'captcha')
         return join(cm.CRAWL_DIR, "_".join(map(str, attributes)))
 

--- a/tbcrawler/pytbcrawler.py
+++ b/tbcrawler/pytbcrawler.py
@@ -52,7 +52,9 @@ def run():
 
     # Instantiate crawler
     crawl_type = getattr(crawler_mod, "Crawler" + args.type)
-    crawler = crawl_type(driver, controller, args.screenshots)
+    crawler = crawl_type(driver, controller,
+                         device=args.device,
+                         screenshots=args.screenshots)
 
     # Configure crawl
     job_config = ut.get_dict_subconfig(config, args.config, "job")
@@ -69,6 +71,8 @@ def run():
         wl_log.warning("Keyboard interrupt! Quitting...")
         sys.exit(-1)
     finally:
+        driver.quit()
+        controller.quit()
         # Post crawl
         post_crawl()
 
@@ -154,6 +158,9 @@ def parse_arguments():
     parser.add_argument('-s', '--screenshots', action='store_true',
                         help='Capture page screenshots',
                         default=False)
+    parser.add_argument('-d', '--device', action='store_true',
+                        help='Interface to sniff the network traffic',
+                        default="eth0")
 
     # Limit crawl
     parser.add_argument('--start', type=int,

--- a/tbcrawler/test/config.ini
+++ b/tbcrawler/test/config.ini
@@ -1,0 +1,47 @@
+[DEFAULT]
+# Tor configuration
+torrc ControlPort=9051
+torrc SocksPort=9050
+torrc SocksBindAddress=127.0.0.1
+
+# Crawl job configuration
+# For understanding batch and visit parameters please refer
+# to Wang and Goldberg's WPES'13 paper, Section 4.1.4
+job batches=1
+job visits=1
+
+# pauses (seconds)
+# pause between two batches
+job pause_between_batches=5
+# pause before crawling a new site
+job pause_between_sites=5
+# pause before visiting the same site (instances)
+job pause_between_visits=4
+# time to wait after the page loads
+job pause_in_site=5
+
+[default]
+# Tor browser configuration
+# The options in this section are just for demonstration and
+# are already set by tbselenium.
+ffpref browser.startup.page=0
+ffpref browser.startup.homepage=about:newtab
+
+[wang_and_goldberg]
+job batches=10
+job visits=4
+
+# Force to reuse circuits as much as possible
+torrc MaxCircuitDirtiness=600000
+
+# Wang and Goldberg: do not fix the entry guard
+torrc UseEntryGuards=0
+
+# configure randomized pipelining
+ffpref network.http.pipelining.max-optimistic-requests=5000
+ffpref network.http.pipelining.maxrequests=15000
+ffpref network.http.pipelining=False
+
+[captcha_test]
+job batches=1
+job visits=2

--- a/tbcrawler/test/config.ini
+++ b/tbcrawler/test/config.ini
@@ -45,3 +45,7 @@ ffpref network.http.pipelining=False
 [captcha_test]
 job batches=1
 job visits=2
+
+[test_captcha_not_captcha_2_batches]
+job batches=2
+job visits=2

--- a/tbcrawler/test/test_crawler.py
+++ b/tbcrawler/test/test_crawler.py
@@ -1,9 +1,16 @@
 import os
 import shutil
+import ConfigParser
 import unittest
+from glob import glob
 from os.path import isfile, isdir
 
-from tbcrawler import common as cm
+from tbcrawler import common as cm, utils as ut
+import netifaces
+from tbcrawler.torcontroller import TorController
+from tbcrawler.pytbcrawler import TorBrowserWrapper, setup_virtual_display, build_crawl_dirs
+from tbselenium.common import USE_RUNNING_TOR
+from tbcrawler import crawler as crawler_mod
 from tbcrawler.crawler import CrawlerBase
 
 TEST_URL_LIST = ['https://www.google.de',
@@ -12,6 +19,43 @@ TEST_URL_LIST = ['https://www.google.de',
 
 
 class CrawlerTest(unittest.TestCase):
+    def setUp(self):
+        cm.CONFIG_FILE = os.path.join(cm.TEST_DIR, 'config.ini')
+        self.config = ConfigParser.RawConfigParser()
+        self.config.read(cm.CONFIG_FILE)
+        self.config_section = 'captcha_test'
+        device = netifaces.gateways()['default'][netifaces.AF_INET][1]
+        tbb_dir = os.path.abspath(cm.TBB_DIR)
+
+        # Configure controller
+        torrc_config = ut.get_dict_subconfig(self.config,
+                                             self.config_section, "torrc")
+        self.controller = TorController(tbb_dir,
+                                   torrc_dict=torrc_config,
+                                   pollute=False)
+
+        # Configure browser
+        ffprefs = ut.get_dict_subconfig(self.config,
+                                        self.config_section, "ffpref")
+        self.driver = TorBrowserWrapper(tbb_dir,
+                                   tbb_logfile_path=os.path.join(cm.LOGS_DIR,
+                                                                 'ff.log'),
+                                   tor_cfg=USE_RUNNING_TOR,
+                                   pref_dict=ffprefs,
+                                   socks_port=int(torrc_config['socksport']),
+                                   canvas_allowed_hosts=[])
+
+        # Instantiate crawler
+        _type = 'WebFP'
+        crawl_type = getattr(crawler_mod, "Crawler" + _type)
+        screenshots = True
+        self.crawler = crawl_type(self.driver, self.controller,
+                                  device=device, screenshots=screenshots)
+
+        # Run display
+        virtual_display = ''
+        self.xvfb_display = setup_virtual_display(virtual_display)
+
     @unittest.skip("TODO. skip for now")
     def test_crawl(self):
         # this test takes at least a few minutes to finish
@@ -35,6 +79,27 @@ class CrawlerTest(unittest.TestCase):
         shutil.rmtree(crawler.crawl_dir)
         os.remove(tar_gz_crawl_data)
 
+    def test_cloudflare_captcha_page(self):
+        expected_pcaps = 2
+
+        url = 'https://cloudflare.com/'
+        job_config = ut.get_dict_subconfig(self.config,
+                                           self.config_section, "job")
+
+        job = crawler_mod.CrawlJob(job_config, [url])
+        cm.CRAWL_DIR = os.path.join(cm.TEST_DIR,
+                                    'test_cloudflare_captcha_results')
+        build_crawl_dirs()
+        os.chdir(cm.CRAWL_DIR)
+        try:
+            self.crawler.crawl(job)  # we can pass batch and instance numbers
+        finally:
+            self.driver.quit()
+            self.controller.quit()
+
+        capture_dirs = glob(os.path.join(cm.CRAWL_DIR, 'captcha_*'))
+        self.assertEqual(expected_pcaps, len(capture_dirs))
+        shutil.rmtree(cm.CRAWL_DIR)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tbcrawler/test/test_crawler.py
+++ b/tbcrawler/test/test_crawler.py
@@ -23,35 +23,39 @@ class CrawlerTest(unittest.TestCase):
         cm.CONFIG_FILE = os.path.join(cm.TEST_DIR, 'config.ini')
         self.config = ConfigParser.RawConfigParser()
         self.config.read(cm.CONFIG_FILE)
-        self.config_section = 'captcha_test'
+
+    def configure_crawler(self, crawl_type, config_section):
         device = netifaces.gateways()['default'][netifaces.AF_INET][1]
         tbb_dir = os.path.abspath(cm.TBB_DIR)
 
         # Configure controller
         torrc_config = ut.get_dict_subconfig(self.config,
-                                             self.config_section, "torrc")
+                                             config_section, "torrc")
         self.controller = TorController(tbb_dir,
-                                   torrc_dict=torrc_config,
-                                   pollute=False)
+                                        torrc_dict=torrc_config,
+                                        pollute=False)
 
         # Configure browser
         ffprefs = ut.get_dict_subconfig(self.config,
-                                        self.config_section, "ffpref")
+                                        config_section, "ffpref")
+        tbb_logfile_path = os.path.join(cm.LOGS_DIR, 'ff.log')
+        socks_port = int(torrc_config['socksport'])
         self.driver = TorBrowserWrapper(tbb_dir,
-                                   tbb_logfile_path=os.path.join(cm.LOGS_DIR,
-                                                                 'ff.log'),
-                                   tor_cfg=USE_RUNNING_TOR,
-                                   pref_dict=ffprefs,
-                                   socks_port=int(torrc_config['socksport']),
-                                   canvas_allowed_hosts=[])
+                                        tbb_logfile_path=tbb_logfile_path,
+                                        tor_cfg=USE_RUNNING_TOR,
+                                        pref_dict=ffprefs,
+                                        socks_port=socks_port,
+                                        canvas_allowed_hosts=[])
 
         # Instantiate crawler
-        _type = 'WebFP'
-        crawl_type = getattr(crawler_mod, "Crawler" + _type)
+        crawl_type = getattr(crawler_mod, "Crawler" + crawl_type)
         screenshots = True
         self.crawler = crawl_type(self.driver, self.controller,
                                   device=device, screenshots=screenshots)
 
+        # Configure job
+        self.job_config = ut.get_dict_subconfig(self.config,
+                                                config_section, "job")
         # Run display
         virtual_display = ''
         self.xvfb_display = setup_virtual_display(virtual_display)
@@ -82,11 +86,10 @@ class CrawlerTest(unittest.TestCase):
     def test_cloudflare_captcha_page(self):
         expected_pcaps = 2
 
-        url = 'https://cloudflare.com/'
-        job_config = ut.get_dict_subconfig(self.config,
-                                           self.config_section, "job")
+        self.configure_crawler('WebFP', 'captcha_test')
 
-        job = crawler_mod.CrawlJob(job_config, [url])
+        url = 'https://cloudflare.com/'
+        job = crawler_mod.CrawlJob(self.job_config, [url])
         cm.CRAWL_DIR = os.path.join(cm.TEST_DIR,
                                     'test_cloudflare_captcha_results')
         build_crawl_dirs()
@@ -101,5 +104,55 @@ class CrawlerTest(unittest.TestCase):
         self.assertEqual(expected_pcaps, len(capture_dirs))
         shutil.rmtree(cm.CRAWL_DIR)
 
+    def test_not_captcha_after_captcha(self):
+        self.configure_crawler('WebFP', 'captcha_test')
+
+        known_captcha_url = 'https://cloudflare.com'
+        known_not_captcha_url = 'https://check.torproject.org/'
+        urls = [known_captcha_url, known_not_captcha_url]
+        job = crawler_mod.CrawlJob(self.job_config, urls)
+        cm.CRAWL_DIR = os.path.join(cm.TEST_DIR,
+                                    'test_not_captcha_after_captcha')
+        self.run_crawl(job)
+
+        for _dir in os.listdir(cm.CRAWL_DIR):
+            marked_captcha = _dir.startswith('captcha_')
+            is_torproject_dir = '_1_' in _dir
+            if is_torproject_dir:
+                self.assertTrue(not marked_captcha)
+            else:
+                self.assertTrue(marked_captcha)
+
+        shutil.rmtree(cm.CRAWL_DIR)
+
+    def test_captcha_not_captcha_2_batches(self):
+        self.configure_crawler('WebFP', 'test_captcha_not_captcha_2_batches')
+
+        known_captcha_url = 'https://cloudflare.com'
+        known_not_captcha_url = 'https://check.torproject.org/'
+        urls = [known_captcha_url, known_not_captcha_url]
+        job = crawler_mod.CrawlJob(self.job_config, urls)
+        cm.CRAWL_DIR = os.path.join(cm.TEST_DIR,
+                                    'test_not_captcha_after_captcha')
+        self.run_crawl(job)
+
+        for _dir in os.listdir(cm.CRAWL_DIR):
+            marked_captcha = _dir.startswith('captcha_')
+            is_torproject_dir = _dir.split('_')[-2] is '1'
+            if is_torproject_dir:
+                self.assertTrue(not marked_captcha)
+            else:
+                self.assertTrue(marked_captcha)
+
+        shutil.rmtree(cm.CRAWL_DIR)
+
+    def run_crawl(self, job):
+        build_crawl_dirs()
+        os.chdir(cm.CRAWL_DIR)
+        try:
+            self.crawler.crawl(job)  # we can pass batch and instance numbers
+        finally:
+            self.driver.quit()
+            self.controller.quit()
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
CrawlJob is informed of the captcha. It renames the corresponding
directory and annotates that it is a captcha, so that its "path"
property maps to the correct renamed directory if appropriate

We should refine the reaction to a captcha page, indeed. This is a first
step, that for me it works for the google recaptcha engine used by
Cloudflare.

Added a test for this functionality, that checks that there are two
directory beginning with 'captcha_' in a 1-batch 2-visits crawl of
https://cloudflare.com.

Since my machine does not have 'eth0', I've added a library (netifaces)
that allows me to select an interface connected to the internet. We
could use this in the future, to improve the portability across
different Linux distros/OSes. So far, I've added a command line argument
to specify a concrete interface by hand. By default, the device is
'eth0' but now you have to tell the Sniffer from which device you want
to sniff.

Regarding robustness, in the try/finally block of pytbcrawler I make
sure both the driver and the controller quit before exiting. This avoids
the problem of having a tor instance running if an exception happens
inside the code or if the user interrupts the execution using the
keyboard. I've tested it in the test_cloudflare_captcha_page, but not in
a "real" crawl.

Edited: new commit message.
