### PR TITLE
Digital Ocean deployment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__
 playbook.retry
 *.swp
 /tor-browser_en-US/
+/*.json
+*~

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -9,25 +9,43 @@ then skip straight to step 2 in the README.
 Requirements
 ---------------
 * Linux packages: `vagrant ansible docker`
+* For VirtualBox deployments: `virtualbox` and `virtualbox-guest-additions`.
+* For Digital Ocean deployments: `vagrant plugin install vagrant-digitalocean`.
 
 Note you can also install ansible with pip, but note pip does not sign packages
 and you probably don't want to run unsigned code as root.
 
-### 1. Configure the environment
-
-* Be sure to add your user to the docker group according to [the instructions on
-the Docker website](https://docs.docker.com/engine/installation/linux/) and
-then log in and back out, so you don't have to run your containers as root.
-
-* You'll still have disable offloads manually because doing so from within
-Docker requires running it in privileged mode:
-`sudo ethtool -K <interface> tx off rx off tso off gso off gro off lro off`
-
-* Create and provision the container: `vagrant up --provider docker`
-
-* SSH into the container: `vagrant ssh`
+Usage
+=====
+* SSH into a machine: `vagrant ssh`.
+If there are several machines, append the name of the one you want to use.
 
 * Once authenticated, maybe you'll want to start tmux (if you're into that sort
 of thing), and you'll definitely want to run `workon tb-crawler` to activate
 the 'tb-crawler' environment (courtesy of virtualenvwrapper), which already
 has all the pip dependencies for tor-browser-crawler installed.
+
+General configuration
+=======================
+* You'll still have disable offloads manually:
+`sudo ethtool -K <interface> tx off rx off tso off gso off gro off lro off`
+
+Docker configuration
+=====================
+
+* Be sure to add your user to the docker group according to [the instructions on
+the Docker website](https://docs.docker.com/engine/installation/linux/) and
+then log in and back out, so you don't have to run your containers as root.
+
+* Create and provision the container: `vagrant up --provider docker`
+
+VirtualBox configuration
+==========================
+* `vagrant up --provider virtualbox` will create and provision the machines.
+
+Digital Ocean configuration
+=============================
+* Define machine configurations in ./digital-ocean-machines.json
+  following the template given in ./skel/.
+
+* `vagrant up --provider digital_ocean` will create and provision the machines.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,25 @@ Vagrant.configure(2) do |config|
     override.vm.box = "debian/jessie64"
   end
 
+  digital_ocean_config = (JSON.parse(File.read("digital-ocean-machines.json")))
+  digital_ocean_config['droplets'].each do |instance|
+    droplet_name   = instance[0]
+    droplet_value = instance[1]
+
+    config.vm.provider :digital_ocean do |droplet, override|
+        override.vm.box = 'digital_ocean'
+        override.vm.box_url = "https://github.com/devopsgroup-io/vagrant-digitalocean/raw/master/box/digital_ocean.box"
+        override.ssh.username = digital_ocean_config['ssh_username']
+        override.ssh.private_key_path = digital_ocean_config['ssh_private_key_path']
+        droplet.token = digital_ocean_config['token']
+
+        override.vm.hostname = droplet_name
+        droplet.image = droplet_value['image']
+        droplet.region = droplet_value['region']
+        droplet.size = droplet_value['ram_size']
+    end
+  end
+
   config.vm.synced_folder "./", "/home/vagrant/tor-browser-crawler/", disabled: false
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbook.yml"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -4,11 +4,12 @@ common_apt_packages:
   - tmux
   - tree
   - vim
+  - gcc
+  - libdbus-glib-1-2 # tor browser bundle
   - git #tbselenium depends
   - python-dev # psutil depends
   - libpcap-dev # pcapy depends
   - gnupg-curl
-  - tor # potentially separate out 
 tbb_arch: 64
 tbb_release: 6.0.3
 tbb_locale: en-US

--- a/roles/common/tasks/download-verify-tbb.yml
+++ b/roles/common/tasks/download-verify-tbb.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create ~/.tbb folder
+- name: Create ~/tbb folder
   file:
     path: "~{{ tbb_username }}/tor-browser-crawler/tbb/"
     state: directory

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -2,6 +2,6 @@
 - include: disable-background-networking.yml
 - include: upgrade-packages.yml
 - include: common-packages.yml
-- include: start-tor-daemon.yml
+# - include: start-tor-daemon.yml
 - include: source-virtualenvwrapper.yml
 - include: download-verify-tbb.yml

--- a/skel/digital-ocean-machines.json
+++ b/skel/digital-ocean-machines.json
@@ -1,0 +1,12 @@
+{
+    "token": "",
+    "ssh_username": "",
+    "ssh_private_key_path": "",
+    "droplets": {
+        "droplet-001": {
+	    "image": "debian-8-x64",
+	    "region": "fra1",
+	    "ram_size": "1gb"
+        }
+    }
+}

--- a/tbcrawler/pytbcrawler.py
+++ b/tbcrawler/pytbcrawler.py
@@ -5,7 +5,7 @@ import traceback
 from contextlib import contextmanager
 from logging import INFO, DEBUG
 from os import stat, chdir
-from os.path import isfile, join
+from os.path import isfile, join, basename
 from shutil import copyfile
 from sys import maxsize, argv
 from urlparse import urlparse
@@ -99,7 +99,7 @@ def build_crawl_dirs():
     ut.create_dir(cm.CRAWL_DIR)
     ut.create_dir(cm.LOGS_DIR)
     copyfile(cm.CONFIG_FILE, join(cm.LOGS_DIR, 'config.ini'))
-    add_symlink(join(cm.RESULTS_DIR, 'latest_crawl'), cm.CRAWL_DIR)
+    add_symlink(join(cm.RESULTS_DIR, 'latest_crawl'), basename(cm.CRAWL_DIR))
 
 
 def parse_url_list(file_path, start, stop):


### PR DESCRIPTION
Instructions about setting up the provider have been added to
AUTOMATION.md.

skel/digital-ocean-machines provides a template to configure the Digital
Ocean deployment.

vagrant rsync complains about absolute path symlinks, because obviously
in the remote machine they are not going to work. I've changed
pytbcrawler so that results/latest_crawl is a relative path symlink
instead.

We also need to install gcc for a pip package, and libdbus-glib-1-2 for
tbb to work on vanilla Debian 8.

We do not need the tor deb package because TBB already provides it. On
the other hand, using a custom built tor binary is also an interesting
option that we may support soon. I leave the start-tor-daemon.yml file
because we may use it anyways, if we manage to install the service
appropriately.
