### PR TITLE
Feature/use custom tor binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__
 playbook.retry
 *.swp
 /tor-browser_en-US/
+/*.json
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ playbook.retry
 /tor-browser_en-US/
 /*.json
 *~
+/tor

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -9,25 +9,43 @@ then skip straight to step 2 in the README.
 Requirements
 ---------------
 * Linux packages: `vagrant ansible docker`
+* For VirtualBox deployments: `virtualbox` and `virtualbox-guest-additions`.
+* For Digital Ocean deployments: `vagrant plugin install vagrant-digitalocean`.
 
 Note you can also install ansible with pip, but note pip does not sign packages
 and you probably don't want to run unsigned code as root.
 
-### 1. Configure the environment
-
-* Be sure to add your user to the docker group according to [the instructions on
-the Docker website](https://docs.docker.com/engine/installation/linux/) and
-then log in and back out, so you don't have to run your containers as root.
-
-* You'll still have disable offloads manually because doing so from within
-Docker requires running it in privileged mode:
-`sudo ethtool -K <interface> tx off rx off tso off gso off gro off lro off`
-
-* Create and provision the container: `vagrant up --provider docker`
-
-* SSH into the container: `vagrant ssh`
+Usage
+=====
+* SSH into a machine: `vagrant ssh`.
+If there are several machines, append the name of the one you want to use.
 
 * Once authenticated, maybe you'll want to start tmux (if you're into that sort
 of thing), and you'll definitely want to run `workon tb-crawler` to activate
 the 'tb-crawler' environment (courtesy of virtualenvwrapper), which already
 has all the pip dependencies for tor-browser-crawler installed.
+
+General configuration
+=======================
+* You'll still have disable offloads manually:
+`sudo ethtool -K <interface> tx off rx off tso off gso off gro off lro off`
+
+Docker configuration
+=====================
+
+* Be sure to add your user to the docker group according to [the instructions on
+the Docker website](https://docs.docker.com/engine/installation/linux/) and
+then log in and back out, so you don't have to run your containers as root.
+
+* Create and provision the container: `vagrant up --provider docker`
+
+VirtualBox configuration
+==========================
+* `vagrant up --provider virtualbox` will create and provision the machines.
+
+Digital Ocean configuration
+=============================
+* Define machine configurations in ./digital-ocean-machines.json
+  following the template given in ./skel/.
+
+* `vagrant up --provider digital_ocean` will create and provision the machines.

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -59,4 +59,8 @@ Compiling Tor from source
 * To compile Tor from source, put the Tor source top directory in ./
 (either copying or symlinking it).
 
+* The compilation in the remote machine will happen if there is a "~/tor" directory in there.
+If you want to disable it, remove that directory both from the local repository dir
+and the remote machine.
+
 * It will be installed in /usr/local/bin.

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -30,8 +30,11 @@ General configuration
 * You'll still have disable offloads manually:
 `sudo ethtool -K <interface> tx off rx off tso off gso off gro off lro off`
 
+Provider specific configurations
+===================================
+
 Docker configuration
-=====================
+----------------------
 
 * Be sure to add your user to the docker group according to [the instructions on
 the Docker website](https://docs.docker.com/engine/installation/linux/) and
@@ -40,12 +43,20 @@ then log in and back out, so you don't have to run your containers as root.
 * Create and provision the container: `vagrant up --provider docker`
 
 VirtualBox configuration
-==========================
+--------------------------
 * `vagrant up --provider virtualbox` will create and provision the machines.
 
 Digital Ocean configuration
-=============================
+------------------------------
 * Define machine configurations in ./digital-ocean-machines.json
   following the template given in ./skel/.
 
 * `vagrant up --provider digital_ocean` will create and provision the machines.
+
+Compiling Tor from source
+============================
+
+* To compile Tor from source, put the Tor source top directory in ./
+(either copying or symlinking it).
+
+* It will be installed in /usr/local/bin.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,25 @@ Vagrant.configure(2) do |config|
     override.vm.box = "debian/jessie64"
   end
 
+  digital_ocean_config = (JSON.parse(File.read("digital-ocean-machines.json")))
+  digital_ocean_config['droplets'].each do |instance|
+    droplet_name   = instance[0]
+    droplet_value = instance[1]
+
+    config.vm.provider :digital_ocean do |droplet, override|
+        override.vm.box = 'digital_ocean'
+        override.vm.box_url = "https://github.com/devopsgroup-io/vagrant-digitalocean/raw/master/box/digital_ocean.box"
+        override.ssh.username = digital_ocean_config['ssh_username']
+        override.ssh.private_key_path = digital_ocean_config['ssh_private_key_path']
+        droplet.token = digital_ocean_config['token']
+
+        override.vm.hostname = droplet_name
+        droplet.image = droplet_value['image']
+        droplet.region = droplet_value['region']
+        droplet.size = droplet_value['ram_size']
+    end
+  end
+
   config.vm.synced_folder "./", "/home/vagrant/tor-browser-crawler/", disabled: false
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbook.yml"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.synced_folder "./", "/home/vagrant/tor-browser-crawler/", disabled: false
+  config.vm.synced_folder "./tor", "/home/vagrant/tor/", disabled: false
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbook.yml"
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,10 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.synced_folder "./", "/home/vagrant/tor-browser-crawler/", disabled: false
-  config.vm.synced_folder "./tor", "/home/vagrant/tor/", disabled: false
+  if File.directory?("./tor")
+    config.vm.synced_folder "./tor", "/home/vagrant/tor/", disabled: false
+  end
+
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbook.yml"
   end

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,6 +4,6 @@
     - stat: path=./tor
       register: tor_dir
   roles:
-    # - role: common
-    # - role: tb-crawler
+    - role: common
+    - role: tb-crawler
     - { role: custom-tor, when: tor_dir.stat.exists }

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,9 @@
 ---
 - hosts: all
-  roles: 
-    - role: common
-    - role: tb-crawler
-    - role: custom-tor
+  pre_tasks:
+    - stat: path=./tor
+      register: tor_dir
+  roles:
+    # - role: common
+    # - role: tb-crawler
+    - { role: custom-tor, when: tor_dir.stat.exists }

--- a/playbook.yml
+++ b/playbook.yml
@@ -3,3 +3,4 @@
   roles: 
     - role: common
     - role: tb-crawler
+    - role: custom-tor

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -4,11 +4,12 @@ common_apt_packages:
   - tmux
   - tree
   - vim
+  - gcc
+  - libdbus-glib-1-2 # tor browser bundle
   - git #tbselenium depends
   - python-dev # psutil depends
   - libpcap-dev # pcapy depends
   - gnupg-curl
-  - tor # potentially separate out 
 tbb_arch: 64
 tbb_release: 6.0.3
 tbb_locale: en-US

--- a/roles/common/tasks/download-verify-tbb.yml
+++ b/roles/common/tasks/download-verify-tbb.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create ~/.tbb folder
+- name: Create ~/tbb folder
   file:
     path: "~{{ tbb_username }}/tor-browser-crawler/tbb/"
     state: directory

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -2,6 +2,6 @@
 - include: disable-background-networking.yml
 - include: upgrade-packages.yml
 - include: common-packages.yml
-- include: start-tor-daemon.yml
+# - include: start-tor-daemon.yml
 - include: source-virtualenvwrapper.yml
 - include: download-verify-tbb.yml

--- a/roles/custom-tor/defaults/main.yml
+++ b/roles/custom-tor/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+tor_apt_packages:
+  - libssl-dev
+  - openssl
+  - zlib
+  - libevent-dev
+  - autoconf
+  - automake
+  - make
+
+tbb_username: "{{ ansible_ssh_user }}"

--- a/roles/custom-tor/defaults/main.yml
+++ b/roles/custom-tor/defaults/main.yml
@@ -2,7 +2,7 @@
 tor_apt_packages:
   - libssl-dev
   - openssl
-  - zlib
+  - zlib1g-dev
   - libevent-dev
   - autoconf
   - automake

--- a/roles/custom-tor/tasks/install-apt-deps.yml
+++ b/roles/custom-tor/tasks/install-apt-deps.yml
@@ -1,0 +1,10 @@
+---
+- name: Install python2.7, tcpdump, wireshark, and xvfb.
+  become: yes
+  apt:
+    name: "{{ item }}"
+    state: latest
+    # Since this role is separate from common, it makes sense to update the pkg
+    # cache before installing these pkgs
+    update_cache: yes
+  with_items: "{{ tb_crawler_apt_packages }}"

--- a/roles/custom-tor/tasks/install-apt-deps.yml
+++ b/roles/custom-tor/tasks/install-apt-deps.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install python2.7, tcpdump, wireshark, and xvfb.
+- name: Install libssl-dev, openssl, zlib1g-dev, libevent-dev, autoconf, automake, make
   become: yes
   apt:
     name: "{{ item }}"
@@ -7,4 +7,4 @@
     # Since this role is separate from common, it makes sense to update the pkg
     # cache before installing these pkgs
     update_cache: yes
-  with_items: "{{ tb_crawler_apt_packages }}"
+  with_items: "{{ tor_apt_packages }}"

--- a/roles/custom-tor/tasks/install-custom-tor.yml
+++ b/roles/custom-tor/tasks/install-custom-tor.yml
@@ -1,0 +1,4 @@
+---
+- name: Make install custom Tor
+  command: make install chdir="~{{ tbb_username }}/tor"
+  become: yes    

--- a/roles/custom-tor/tasks/main.yml
+++ b/roles/custom-tor/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
-- include: install-apt-deps.yml
-- include: make-tor-from-source.yml
-- include: install-custom-tor.yml
+
+- name: Install apt dependencies if ~/tor exists
+  include: install-apt-deps.yml
+
+- name: Compile Tor if ~/tor/autogen.sh exists
+  include: make-tor-from-source.yml
+
+- name: Install Tor if the compilation succeeded
+  include: install-custom-tor.yml

--- a/roles/custom-tor/tasks/main.yml
+++ b/roles/custom-tor/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- include: install-apt-deps.yml
+- include: make-tor-from-source.yml
+- include: install-custom-tor.yml

--- a/roles/custom-tor/tasks/make-tor-from-source.yml
+++ b/roles/custom-tor/tasks/make-tor-from-source.yml
@@ -1,0 +1,10 @@
+---
+- name: Autogen custom Tor.
+  command: ./autogen.sh chdir="~{{ tbb_username }}/tor"
+
+- name: Configure custom Tor.
+  command: ./configure --disable-asciidoc chdir="~{{ tbb_username }}/tor"
+
+- name: Make custom Tor
+  command: make chdir="~{{ tbb_username }}/tor"
+    

--- a/skel/digital-ocean-machines.json
+++ b/skel/digital-ocean-machines.json
@@ -1,0 +1,12 @@
+{
+    "token": "",
+    "ssh_username": "",
+    "ssh_private_key_path": "",
+    "droplets": {
+        "droplet-001": {
+	    "image": "debian-8-x64",
+	    "region": "fra1",
+	    "ram_size": "1gb"
+        }
+    }
+}

--- a/tbcrawler/pytbcrawler.py
+++ b/tbcrawler/pytbcrawler.py
@@ -5,7 +5,7 @@ import traceback
 from contextlib import contextmanager
 from logging import INFO, DEBUG
 from os import stat, chdir
-from os.path import isfile, join
+from os.path import isfile, join, basename
 from shutil import copyfile
 from sys import maxsize, argv
 from urlparse import urlparse
@@ -99,7 +99,7 @@ def build_crawl_dirs():
     ut.create_dir(cm.CRAWL_DIR)
     ut.create_dir(cm.LOGS_DIR)
     copyfile(cm.CONFIG_FILE, join(cm.LOGS_DIR, 'config.ini'))
-    add_symlink(join(cm.RESULTS_DIR, 'latest_crawl'), cm.CRAWL_DIR)
+    add_symlink(join(cm.RESULTS_DIR, 'latest_crawl'), basename(cm.CRAWL_DIR))
 
 
 def parse_url_list(file_path, start, stop):

--- a/tbcrawler/pytbcrawler.py
+++ b/tbcrawler/pytbcrawler.py
@@ -145,7 +145,7 @@ def parse_arguments():
                         default=cm.TBB_DIR)
     parser.add_argument('-r', '--tor-binary-path',
                         help="Path to the Tor binary.")
-    parser.add_argument('-d', '--tor-data-path',
+    parser.add_argument('-a', '--tor-data-path',
                         help="Path to the Tor data directory.")
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='increase output verbosity',

--- a/tbcrawler/pytbcrawler.py
+++ b/tbcrawler/pytbcrawler.py
@@ -37,7 +37,20 @@ def run():
 
     # Configure controller
     torrc_config = ut.get_dict_subconfig(config, args.config, "torrc")
-    controller = TorController(tbb_path=args.tbb_path,
+    if args.tor_binary_path and args.tor_data_path:
+        tbb_path = None
+        tor_binary_path = args.tor_binary_path
+        tor_data_path = args.tor_data_path
+        wl_log.info("Using custom Tor in %s" % tor_binary_path)
+    else:
+        tbb_path = args.tbb_path
+        tor_binary_path = None
+        tor_data_path = None
+        wl_log.info("Using Tor Browser Bundle in %s" % tbb_path)
+
+    controller = TorController(tbb_path=tbb_path,
+                               tor_binary_path=tor_binary_path,
+                               tor_data_path=tor_data_path,
                                torrc_dict=torrc_config,
                                pollute=False)
 
@@ -141,6 +154,10 @@ def parse_arguments():
     parser.add_argument('-b', '--tbb-path',
                         help="Path to the Tor Browser Bundle directory.",
                         default=cm.TBB_DIR)
+    parser.add_argument('-r', '--tor-binary-path',
+                        help="Path to the Tor binary.")
+    parser.add_argument('-d', '--tor-data-path',
+                        help="Path to the Tor data directory.")
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='increase output verbosity',
                         default=False)

--- a/tbcrawler/pytbcrawler.py
+++ b/tbcrawler/pytbcrawler.py
@@ -37,20 +37,9 @@ def run():
 
     # Configure controller
     torrc_config = ut.get_dict_subconfig(config, args.config, "torrc")
-    if args.tor_binary_path and args.tor_data_path:
-        tbb_path = None
-        tor_binary_path = args.tor_binary_path
-        tor_data_path = args.tor_data_path
-        wl_log.info("Using custom Tor in %s" % tor_binary_path)
-    else:
-        tbb_path = args.tbb_path
-        tor_binary_path = None
-        tor_data_path = None
-        wl_log.info("Using Tor Browser Bundle in %s" % tbb_path)
-
-    controller = TorController(tbb_path=tbb_path,
-                               tor_binary_path=tor_binary_path,
-                               tor_data_path=tor_data_path,
+    controller = TorController(tbb_path=args.tbb_path,
+                               tor_binary_path=args.tor_binary_path,
+                               tor_data_path=args.tor_data_path,
                                torrc_dict=torrc_config,
                                pollute=False)
 

--- a/tbcrawler/pytbcrawler.py
+++ b/tbcrawler/pytbcrawler.py
@@ -37,7 +37,7 @@ def run():
 
     # Configure controller
     torrc_config = ut.get_dict_subconfig(config, args.config, "torrc")
-    controller = TorController(cm.TBB_DIR,
+    controller = TorController(tbb_path=args.tbb_path,
                                torrc_dict=torrc_config,
                                pollute=False)
 

--- a/tbcrawler/torcontroller.py
+++ b/tbcrawler/torcontroller.py
@@ -20,7 +20,8 @@ class TorController(object):
                  torrc_dict={'controlport': '9051', 'socksport': '9050'},
                  pollute=True):
         assert (tbb_path or tor_binary_path and tor_data_path)
-        if tbb_path:
+
+        if tbb_path and not (tor_binary_path and tor_data_path):
             tbb_path = tbb_path.rstrip('/')
             tor_binary_path = join(tbb_path, DEFAULT_TOR_BINARY_PATH)
             tor_data_path = join(tbb_path, DEFAULT_TOR_DATA_PATH)


### PR DESCRIPTION
First merge #30, I needed it to test this feature.

Args to specify tor binary and tor data paths

To use custom built Tor binary, just specify the paths to the binary
itself and the Tor data directory where torrc lives.

(tor-binary-path and tor-data-path) take precedence over tbb-path.
